### PR TITLE
Add support to enable/disable SmudgeKit at will

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Then implement the getter method of the window property in your Application Dele
 
 ```
 
+The smudge effect can be turned on or off at will using the following @property of `UIWindow`:
+
+`@property (nonatomic, getter=isSmudgeKitEnabled) BOOL enableSmudgeKit;`
+
 You can change the appearance by editing the SmudgeLayer implementation in SmudgyWindow.m
 
 

--- a/Source-ObjectiveC/SmudgyWindow.h
+++ b/Source-ObjectiveC/SmudgyWindow.h
@@ -9,11 +9,17 @@
 #import <UIKit/UIKit.h>
 
 /**
+ * Category on UIWindow that adds a property allowing one to
+ * enable/disable SmudgeKit at will
+ */
+@interface UIWindow (SmudgeKitProperties)
+@property (nonatomic, getter=isSmudgeKitEnabled) BOOL enableSmudgeKit;
+@end
+
+/**
  * The SmudgyWindow class is a drop in replacement for UIWindow which
  * draws a visual representation of all touch events onto the screen.
  */
 @interface SmudgyWindow : UIWindow
-
-@property (nonatomic) BOOL enableSmudgeKit;
 
 @end

--- a/Source-ObjectiveC/SmudgyWindow.h
+++ b/Source-ObjectiveC/SmudgyWindow.h
@@ -14,4 +14,6 @@
  */
 @interface SmudgyWindow : UIWindow
 
+@property (nonatomic) BOOL enableSmudgeKit;
+
 @end

--- a/Source-ObjectiveC/SmudgyWindow.m
+++ b/Source-ObjectiveC/SmudgyWindow.m
@@ -176,10 +176,21 @@
 
 @implementation SmudgyWindow
 
+- (void)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self)  {
+        self.enableSmudgeKit = YES;
+    }
+    return self;
+}
+
 - (void)sendEvent:(UIEvent *)event
 {
     [super sendEvent:event];
-    [self renderTouchesForEvent:event];
+    if (self.enableSmudgeKit)  {
+        [self renderTouchesForEvent:event];
+    }
 }
 
 - (void)renderTouchesForEvent:(UIEvent *)event

--- a/Source-ObjectiveC/SmudgyWindow.m
+++ b/Source-ObjectiveC/SmudgyWindow.m
@@ -6,7 +6,28 @@
 //  Copyright (c) 2014 Ideon. All rights reserved.
 //
 
+#import <objc/runtime.h>
+
 #import "SmudgyWindow.h"
+
+#pragma mark - UIWindow category
+
+static const void *EnableSmudgeKitKey = &EnableSmudgeKitKey;
+
+@implementation UIWindow (SmudgeKitProperties)
+
+- (void)setEnableSmudgeKit:(BOOL)enableSmudgeKit
+{
+    objc_setAssociatedObject(self, EnableSmudgeKitKey, [NSNumber numberWithBool:enableSmudgeKit], OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (BOOL)isSmudgeKitEnabled
+{
+    NSNumber *smudgeKitEnabled = objc_getAssociatedObject(self, EnableSmudgeKitKey);
+    return [smudgeKitEnabled boolValue];
+}
+
+@end
 
 #pragma mark - Private SmudgeLayer implementation -
 
@@ -176,7 +197,7 @@
 
 @implementation SmudgyWindow
 
-- (void)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self)  {


### PR DESCRIPTION
Submitted for your consideration is a patch that adds the capability to enable/disable SmudgeKit at will.

There are a few apps that offer a "Demo Mode" that can be turned on/off in preferences that, when enabled, shows the touch points on screen like SmudgeKit does.  (I believe the Omni\* apps do this)   This can be useful, e.g. during normal use, you wouldn't want the touch points being shown, however if you are recording a screencast or demoing an app to people using a projector or Apple TV, then you would want to show the touch points.  So having this a togglable setting is useful I think.
